### PR TITLE
bump the version

### DIFF
--- a/guestbook/guestbook-ui-deployment.yaml
+++ b/guestbook/guestbook-ui-deployment.yaml
@@ -14,7 +14,7 @@ spec:
         app: guestbook-ui
     spec:
       containers:
-      - image: gcr.io/heptio-images/ks-guestbook-demo:latest
+      - image: gcr.io/heptio-images/ks-guestbook-demo:0.2
         name: guestbook-ui
         ports:
         - containerPort: 80


### PR DESCRIPTION
9347f1beaff8003d890954d17c86ea4cd4097ec7 APTEDGE-6247: Update sentiment domain terms for kenna (#2699)
da1e1670f2681d05173bc585a0ebc01dbce2d085 APTEDGE-6503: do not return archived edges in search (#2680)
b6b531bb37d15babdda111db6d64cd36b58d9623 Testing Airflow DBT fix (#2698)
9cede7477e3434d16131aea405a2b7f029cfd5f7 Incorporate useTabHistory for Global Search (#2690)
8d9d429f908f63eea7b102e0f02b0b2b67f8693f Aptedge 5855 handoff (#2635)
97351296611c0fe9163f791e1132bd31fb95ab4a APTEDGE-6367: Add approximate result counts to Edge and Ticket listings (#2687)